### PR TITLE
Ensure intro is not null. If it is null set to a blank string to avoi…

### DIFF
--- a/backup/moodle2/restore_goone_stepslib.php
+++ b/backup/moodle2/restore_goone_stepslib.php
@@ -69,6 +69,11 @@ class restore_goone_activity_structure_step extends restore_activity_structure_s
         // See MDL-9367.
         $data->timeopen = $this->apply_date_offset($data->timeopen);
         $data->timeclose = $this->apply_date_offset($data->timeclose);
+        
+        // Ensure intro is not null. If it is null set to a blank string to avoid DB error.
+        if (!property_exists($data, 'intro')) {
+            $data->intro = '';
+        }
 
         // Insert the goone record.
         $newitemid = $DB->insert_record('goone', $data);


### PR DESCRIPTION
…d DB error.

Current if a Go1 activity has no description set there are errors when the activity is restored as part of a backup.
This is due to the intro field in the mod_goone table being set to not allow nulls.
This code change ensures that the field is set to a blank string if it is null when importing.